### PR TITLE
Verify the hash signature in HTTP headers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,8 @@ GEM
     rack (1.6.5)
     rack-protection (1.5.3)
       rack
+    rack-test (0.6.3)
+      rack (>= 1.0)
     rake (10.4.2)
     rspec (3.3.0)
       rspec-core (~> 3.3.0)
@@ -71,6 +73,7 @@ DEPENDENCIES
   codeclimate-test-reporter
   prpr!
   pry
+  rack-test
   rake (~> 10.0)
   rspec
   ultrahook

--- a/bin/server
+++ b/bin/server
@@ -3,20 +3,4 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'prpr'
-require "sinatra/base"
-
-class PrprServer < Sinatra::Base
-  enable :logging
-
-  post '/' do
-    begin
-      Prpr::Runner.new.call params['payload'], event: request.env['HTTP_X_GITHUB_EVENT']
-      'ok'
-    rescue => e
-      logger.error e.message
-      "Error: #{e.message}\n#{e.backtrace}"
-    end
-  end
-
-  run!
-end
+Prpr::Server.run!

--- a/lib/prpr.rb
+++ b/lib/prpr.rb
@@ -1,5 +1,6 @@
 require 'prpr/version'
 require 'prpr/runner'
+require 'prpr/server'
 require 'prpr/config/env'
 require 'prpr/config/github'
 require 'prpr/repository/github'

--- a/lib/prpr/server.rb
+++ b/lib/prpr/server.rb
@@ -6,12 +6,26 @@ module Prpr
 
     post '/' do
       begin
+        request.body.rewind
+        payload_body = request.body.read
+        verify_signature(payload_body)
+
         Prpr::Runner.new.call params['payload'], event: request.env['HTTP_X_GITHUB_EVENT']
         'ok'
       rescue => e
         logger.error e.message
         "Error: #{e.message}\n#{e.backtrace}"
       end
+    end
+
+    private
+
+    def verify_signature(payload_body)
+      env = Prpr::Config::Env.default
+      return unless env[:secret_token]
+
+      signature = 'sha1=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), env[:secret_token], payload_body)
+      return halt 500, "Signatures didn't match!" unless Rack::Utils.secure_compare(signature, request.env['HTTP_X_HUB_SIGNATURE'])
     end
   end
 end

--- a/lib/prpr/server.rb
+++ b/lib/prpr/server.rb
@@ -1,0 +1,17 @@
+require "sinatra/base"
+
+module Prpr
+  class Server < Sinatra::Base
+    enable :logging
+
+    post '/' do
+      begin
+        Prpr::Runner.new.call params['payload'], event: request.env['HTTP_X_GITHUB_EVENT']
+        'ok'
+      rescue => e
+        logger.error e.message
+        "Error: #{e.message}\n#{e.backtrace}"
+      end
+    end
+  end
+end

--- a/prpr.gemspec
+++ b/prpr.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "ultrahook"
+  spec.add_development_dependency "rack-test"
 end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+RSpec.describe Prpr::Server do
+  include Rack::Test::Methods
+
+  def app
+    Prpr::Server
+  end
+
+  it 'accepts a request for the pull_request event' do
+    headers = { 'HTTP_X_GITHUB_EVENT' => 'pull_request' }
+    post '/', { payload: '{}' }, headers
+
+    expect(last_response).to be_ok
+    expect(last_response.body).to eq 'ok'
+  end
+
+  it 'returns an error response for the unknown event' do
+    headers = { 'HTTP_X_GITHUB_EVENT' => 'unknown' }
+    post '/', { payload: '{}' }, headers
+
+    expect(last_response).to be_ok
+    expect(last_response.body).to start_with 'Error:'
+  end
+end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -22,4 +22,37 @@ RSpec.describe Prpr::Server do
     expect(last_response).to be_ok
     expect(last_response.body).to start_with 'Error:'
   end
+
+  def make_signature(token, content)
+    'sha1=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), token, content)
+  end
+
+  context 'set SECRET_TOKEN' do
+    let(:env) { { secret_token: 'secret_token' } }
+    before { allow(Prpr::Config::Env).to receive(:default) { env } }
+
+    it 'accepts a request with valid signature' do
+      signature = make_signature(env[:secret_token], 'payload=%7B%7D')
+      headers = {
+        'HTTP_X_GITHUB_EVENT' => 'pull_request',
+        'HTTP_X_HUB_SIGNATURE' => signature,
+      }
+      post '/', { payload: '{}' }, headers
+
+      expect(last_response).to be_ok
+      expect(last_response.body).to eq 'ok'
+    end
+
+    it 'returns an error response for the invalid request' do
+      signature = 'sha1=' + 'A' * 20
+      headers = {
+        'HTTP_X_GITHUB_EVENT' => 'pull_request',
+        'HTTP_X_HUB_SIGNATURE' => signature
+      }
+      post '/', { payload: '{}' }, headers
+
+      expect(last_response).to be_server_error
+      expect(last_response.body).to eq "Signatures didn't match!"
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'prpr'
 require 'pathname'
+require 'rack/test'
 
 require "codeclimate-test-reporter"
 CodeClimate::TestReporter.start


### PR DESCRIPTION
Add support for Validating payloads from GitHub.

see also: https://developer.github.com/webhooks/securing/