### PR TITLE
Add a command to create a hook

### DIFF
--- a/bin/webhook
+++ b/bin/webhook
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+require 'prpr'
+
+repo, url = ARGV[0..1]
+webhook = Prpr::Webhook.new(repo, url)
+hook = webhook.create_or_update
+puts webhook.url_for(hook)

--- a/lib/prpr.rb
+++ b/lib/prpr.rb
@@ -1,5 +1,6 @@
 require 'prpr/version'
 require 'prpr/runner'
+require 'prpr/webhook'
 require 'prpr/config/env'
 require 'prpr/config/github'
 require 'prpr/repository/github'

--- a/lib/prpr/event/event.rb
+++ b/lib/prpr/event/event.rb
@@ -8,23 +8,22 @@ module Prpr
 
     class Event
       class << self
+        def events
+          {
+            commit_comment: CommitComment,
+            issue_comment: IssueComment,
+            pull_request: PullRequest,
+            pull_request_review: PullRequestReview,
+            pull_request_review_comment: PullRequestReviewComment,
+            push: Push
+          }
+        end
+
         def parse(payload, event:)
-          case event
-          when 'pull_request'
-            PullRequest.new(JSON.parse(payload))
-          when 'push'
-            Push.new(JSON.parse(payload))
-          when 'issue_comment'
-            IssueComment.new(JSON.parse(payload))
-          when 'commit_comment'
-            CommitComment.new(JSON.parse(payload))
-          when 'pull_request_review'
-            PullRequestReview.new(JSON.parse(payload))
-          when 'pull_request_review_comment'
-            PullRequestReviewComment.new(JSON.parse(payload))
-          else
-            fail UnknownEvent, event
-          end
+          klass = events[event.to_sym]
+          fail UnknownEvent, event unless klass
+
+          klass.new(JSON.parse(payload))
         end
       end
     end

--- a/lib/prpr/webhook.rb
+++ b/lib/prpr/webhook.rb
@@ -3,7 +3,6 @@ module Prpr
     attr_reader :repo, :url
 
     MSG = 'USAGE: bin/webhook <repo> <url>'.freeze
-    EVENTS = %w(pull_request push issue_comment commit_comment pull_request_review pull_request_review_comment).freeze
 
     def initialize(repo, url)
       @repo = repo
@@ -14,7 +13,7 @@ module Prpr
       fail MSG unless valid?
 
       config = { url: url, secret: secret }
-      options = { events: EVENTS }
+      options = { events: Event::Event.events.keys }
       if hook
         client.edit_hook(repo, hook.id, 'web', config, options)
       else

--- a/lib/prpr/webhook.rb
+++ b/lib/prpr/webhook.rb
@@ -1,0 +1,52 @@
+module Prpr
+  class Webhook
+    attr_reader :repo, :url
+
+    MSG = 'USAGE: bin/webhook <repo> <url>'.freeze
+    EVENTS = %w(pull_request push issue_comment commit_comment pull_request_review pull_request_review_comment).freeze
+
+    def initialize(repo, url)
+      @repo = repo
+      @url = url
+    end
+
+    def create_or_update
+      fail MSG unless valid?
+
+      config = { url: url, secret: secret }
+      options = { events: EVENTS }
+      if hook
+        client.edit_hook(repo, hook.id, 'web', config, options)
+      else
+        client.create_hook(repo, 'web', config, options)
+      end
+    end
+
+    def url_for(hook)
+      host = Prpr::Repository::Github.github_host || 'github.com'
+      "https://#{host}/#{repo}/settings/hooks/#{hook.id}"
+    end
+
+    private
+
+    def valid?
+      repo.to_s.split('/').size == 2 && url.to_s =~ URI.regexp
+    end
+
+    def hook
+      @hook ||= client.hooks(repo).find { |hook| hook.config.url == url }
+    end
+
+    def client
+      @client ||= Prpr::Repository::Github.default
+    end
+
+    def env
+      @env ||= Prpr::Config::Env.default
+    end
+
+    def secret
+      env[:secret_token]
+    end
+  end
+end

--- a/spec/webhook_spec.rb
+++ b/spec/webhook_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Prpr::Webhook do
           hook.id,
           'web',
           { url: url, secret: env[:secret_token] },
-          events: Prpr::Webhook::EVENTS)
+          events: Prpr::Event::Event.events.keys)
       end
     end
 
@@ -60,7 +60,7 @@ RSpec.describe Prpr::Webhook do
           repo,
           'web',
           { url: url, secret: env[:secret_token] },
-          events: Prpr::Webhook::EVENTS)
+          events: Prpr::Event::Event.events.keys)
       end
     end
   end

--- a/spec/webhook_spec.rb
+++ b/spec/webhook_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+RSpec.describe Prpr::Webhook do
+  describe '#create_or_update' do
+    let(:repo) { 'mzp/prpr' }
+    let(:url) { 'http://prpr.example.com' }
+    let(:webhook) { Prpr::Webhook.new(repo, url) }
+
+    context 'initialize with invalid args' do
+      subject { Prpr::Webhook.new(nil, nil).create_or_update }
+      it { expect { subject }.to raise_error Prpr::Webhook::MSG }
+    end
+
+    shared_context 'stub Webhooks API' do
+      let(:env) { { secret_token: 'secret_token' } }
+      let(:client) { instance_double(Octokit::Client, hooks: [], create_hook: nil, edit_hook: nil) }
+
+      before do
+        allow(hook).to receive_message_chain(:config, :url).and_return(url)
+        allow(Prpr::Config::Env).to receive(:default) { env }
+        allow(webhook).to receive(:client) { client }
+      end
+    end
+
+    context 'a hook has already saved' do
+      include_context 'stub Webhooks API'
+
+      let(:hook) { double('hook', id: 1) }
+
+      before do
+        allow(client).to receive(:hooks).and_return([hook])
+        allow(client).to receive(:edit_hook).and_return(hook)
+      end
+
+      it 'update a hook' do
+        expect(webhook.create_or_update).to eq hook
+
+        expect(client).to have_received(:hooks).with(repo)
+        expect(client).to have_received(:edit_hook).with(
+          repo,
+          hook.id,
+          'web',
+          { url: url, secret: env[:secret_token] },
+          events: Prpr::Webhook::EVENTS)
+      end
+    end
+
+    context 'a hook not exist' do
+      include_context 'stub Webhooks API'
+
+      let(:hook) { double('hook') }
+
+      before { allow(client).to receive(:create_hook).and_return(hook) }
+
+      it 'create a hook' do
+        expect(webhook.create_or_update).to eq hook
+
+        expect(client).to have_received(:hooks).with(repo)
+        expect(client).to have_received(:create_hook).with(
+          repo,
+          'web',
+          { url: url, secret: env[:secret_token] },
+          events: Prpr::Webhook::EVENTS)
+      end
+    end
+  end
+end


### PR DESCRIPTION
I would like to create a hook more easily, so I added a command. You can use it as below:

```sh
$ GITHUB_ACCESS_TOKEN=xxx bin/webhoook mzp/prpr http://prpr.example.com
```

It can also be used via the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli).

```sh
$ heroku run bin/webhook mzp/prpr http://prpr.example.com
```

note: This command requires the secret token that include the [**admin:repo_hook**](https://developer.github.com/v3/oauth/#scopes) scope.
