### PR TITLE
Ignore unknown events

### DIFF
--- a/lib/prpr/server.rb
+++ b/lib/prpr/server.rb
@@ -12,6 +12,8 @@ module Prpr
 
         Prpr::Runner.new.call params['payload'], event: request.env['HTTP_X_GITHUB_EVENT']
         'ok'
+      rescue Prpr::Event::UnknownEvent => e
+        "Unsupported: #{e.message}"
       rescue => e
         logger.error e.message
         "Error: #{e.message}\n#{e.backtrace}"

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -15,8 +15,10 @@ RSpec.describe Prpr::Server do
     expect(last_response.body).to eq 'ok'
   end
 
-  it 'returns an error response for the unknown event' do
-    headers = { 'HTTP_X_GITHUB_EVENT' => 'unknown' }
+  it 'returns an error response with error' do
+    expect_any_instance_of(Prpr::Runner).to receive(:call).and_raise('test error')
+
+    headers = { 'HTTP_X_GITHUB_EVENT' => 'pull_request' }
     post '/', { payload: '{}' }, headers
 
     expect(last_response).to be_ok

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -15,6 +15,16 @@ RSpec.describe Prpr::Server do
     expect(last_response.body).to eq 'ok'
   end
 
+  it 'returns an unsupported response for unsupported events' do
+    expect_any_instance_of(Logger).not_to receive(:error)
+
+    headers = { 'HTTP_X_GITHUB_EVENT' => 'status' }
+    post '/', { payload: '{}' }, headers
+
+    expect(last_response).to be_ok
+    expect(last_response.body).to eq 'Unsupported: status'
+  end
+
   it 'returns an error response with error' do
     expect_any_instance_of(Prpr::Runner).to receive(:call).and_raise('test error')
 


### PR DESCRIPTION
I find that prpr writes logs only have `status`:

```
2020-03-24T01:05:45.552938+00:00 app[web.1]: E, [2020-03-24T01:05:45.552775 #8] ERROR -- : status
```

These logs are not useful and noisy. So I want to ignore these.

These logs are written by events that prpr does not support.
prpr currently supports only:

* `commit_comment`
* `issue_comment`
* `pull_request`
* `pull_request_review`
* `pull_request_review_comment`
* `push`

But GitHub WebHook has many many event types: https://developer.github.com/webhooks/

So I changed to ignore these logs.